### PR TITLE
Fix extra-data extraction with runtime bsdtar

### DIFF
--- a/com.xunlei.Thunder.yaml
+++ b/com.xunlei.Thunder.yaml
@@ -28,10 +28,6 @@ modules:
       - install -Dm644 com.xunlei.Thunder.png /app/share/icons/hicolor/256x256/apps/com.xunlei.Thunder.png
       - install -Dm644 com.xunlei.Thunder.desktop /app/share/applications/com.xunlei.Thunder.desktop
       - install -Dm644 com.xunlei.Thunder.appdata.xml /app/share/metainfo/com.xunlei.Thunder.appdata.xml
-
-      - install -D -t /app/lib/ /usr/lib/x86_64-linux-gnu/libbfd-*.so
-      - install -D -t /app/bin/ /usr/bin/ar
-
     sources:
       - type: extra-data
         filename: com.xunlei.download_amd64.deb
@@ -41,10 +37,14 @@ modules:
 
       - type: script
         commands:
-          - ar x com.xunlei.download_amd64.deb
+          # 使用 runtime 自带的 bsdtar 解包 deb，避免依赖 SDK 中 ar/libbfd 的动态库路径。
+          - set -eu
+          - bsdtar -xf com.xunlei.download_amd64.deb data.tar.xz
           - tar -xf data.tar.xz
           - mv ./opt/apps/com.xunlei.download/files ./thunder
-          - rm -rf com.xunlei.download_amd64.deb sign debian-binary control.tar.gz data.tar.xz opt
+          # 明确校验启动文件，防止解包失败后仍然被 Flatpak 当成安装成功。
+          - test -x ./thunder/thunder
+          - rm -rf com.xunlei.download_amd64.deb sign debian-binary control.tar.* data.tar.* opt
         dest-filename: apply_extra
 
       - type: script


### PR DESCRIPTION
## 问题

当前 `apply_extra` 使用从 SDK 复制到 `/app/bin` 的 `ar` 解包 deb，同时复制 `libbfd-*.so` 到 `/app/lib`。在 `org.freedesktop.Platform 25.08` 下，extra-data 解包阶段执行 `/app/bin/ar` 时无法找到 `/app/lib/libbfd-2.45.1.so`，导致 deb 没有被正确解包，最终 `/app/extra/thunder/thunder` 缺失，应用启动时报 `No such file or directory`。

由于原脚本没有显式失败检查，解包失败后 Flatpak 安装仍可能显示成功。

## 修复

- 改用 runtime 自带的 `bsdtar` 解包 deb，避免依赖 SDK 中 `ar/libbfd` 的动态库路径。
- 删除不再需要的 `/usr/bin/ar` 和 `libbfd-*.so` 复制步骤。
- 在 `apply_extra` 中加入 `set -eu`，确保任何一步失败都会使安装阶段直接失败。
- 增加 `test -x ./thunder/thunder`，明确校验最终启动文件存在且可执行。

## 验证

已在 `org.freedesktop.Platform//25.08` runtime 中验证新的解包逻辑：

```bash
flatpak run --filesystem=/var/home/lj/tmp --command=sh org.freedesktop.Platform//25.08 -c 'cd /var/home/lj/tmp/xunlei_pr_apply_test && set -eu && bsdtar -xf com.xunlei.download_amd64.deb data.tar.xz && tar -xf data.tar.xz && mv ./opt/apps/com.xunlei.download/files ./thunder && test -x ./thunder/thunder && ls -la ./thunder/thunder'
```

结果成功生成可执行文件：

```text
-rwxr-xr-x. 1 lj lj 73912232 Sep 27  2020 ./thunder/thunder
```
